### PR TITLE
Add scanning for Salsa20 sigma, tau constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following constants are defined in scan configurations:
  - MD5: initstate and md5_t
  - NewDES: sbox
  - RC5/RC6: combined constant
+ - Salsa20: sigma and tau
  - SHA1: h
  - SHA224: h
  - SHA256: both k and h 

--- a/scans/salsa20_sigma.json
+++ b/scans/salsa20_sigma.json
@@ -1,0 +1,19 @@
+  {
+    "threshold" : 50,
+    "name" : "Salsa20_sigma",
+    "description" : "Detects the sigma constant, used in the 256-bit version of Salsa20, i.e. the string 'expand 32-byte k'",
+    "family" : "Salsa20",
+    "type" : "static",
+    "size" : 4,
+    "flags" : [
+      "0x65", "0x78", "0x70", "0x61",
+      "0x6E", "0x64", "0x20", "0x33",
+      "0x32", "0x2D", "0x62", "0x79",
+      "0x74", "0x65", "0x20", "0x6B"
+    ],
+    "on_match" : {
+    "threshold" : 50,
+      "type" : "symbol",
+      "name" : "Salsa20_sigma"
+    }
+  }

--- a/scans/salsa20_tau.json
+++ b/scans/salsa20_tau.json
@@ -1,0 +1,19 @@
+  {
+    "threshold" : 50,
+    "name" : "Salsa20_tau",
+    "description" : "Detects the tau constant, used in the 128-bit version of Salsa20, i.e. the string 'expand 16-byte k'",
+    "family" : "Salsa20",
+    "type" : "static",
+    "size" : 4,
+    "flags" : [
+      "0x65", "0x78", "0x70", "0x61",
+      "0x6E", "0x64", "0x20", "0x31",
+      "0x36", "0x2D", "0x62", "0x79",
+      "0x74", "0x65", "0x20", "0x6B"
+    ],
+    "on_match" : {
+    "threshold" : 50,
+      "type" : "symbol",
+      "name" : "Salsa20_tau"
+    }
+  }


### PR DESCRIPTION
Added the `sigma` and `tau` magic constants for Salsa20. The `sigma` and `tau` names come from the Salsa20 reference implementation at https://cr.yp.to/snuffle/salsa20/ref/salsa20.c.